### PR TITLE
Improve font sizes throughout portfolio for better readability

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,48 @@
-html{
+html {
     font-family: IBM Plex Mono;
+    font-size: 16px;
 }
 
+body {
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+h1 {
+    font-size: 2.5rem;
+}
+
+h3 {
+    font-size: 1.5rem;
+}
+
+h4 {
+    font-size: 1.25rem;
+}
+
+p {
+    font-size: 1rem;
+}
+
+nav {
+    font-size: 1rem;
+}
+
+/* Responsive font sizes */
+@media (max-width: 768px) {
+    html {
+        font-size: 14px;
+    }
+    
+    h1 {
+        font-size: 2rem;
+    }
+    
+    h3 {
+        font-size: 1.25rem;
+    }
+    
+    h4 {
+        font-size: 1.1rem;
+    }
+}


### PR DESCRIPTION
This PR addresses the Jira ticket to change font sizes in the portfolio by implementing a comprehensive font sizing system.

## Changes Made

### Font Size Improvements
- **Base font size**: Set to 16px for optimal readability
- **Heading hierarchy**: 
  - H1: 2.5rem (40px) for main portfolio introduction
  - H3: 1.5rem (24px) for section headings (About, Projects)
  - H4: 1.25rem (20px) for project titles
- **Body text**: 1rem (16px) with improved line-height of 1.6
- **Navigation**: Consistent 1rem sizing

### Responsive Design
- **Mobile optimization**: Reduced font sizes for screens ≤768px
  - HTML base: 14px
  - H1: 2rem (28px)
  - H3: 1.25rem (17.5px)  
  - H4: 1.1rem (15.4px)

### Benefits
- ✅ Better visual hierarchy
- ✅ Improved readability across devices
- ✅ Consistent typography system
- ✅ Mobile-friendly responsive scaling
- ✅ Maintains existing IBM Plex Mono font family

The changes ensure the portfolio has proper font sizing that enhances user experience while maintaining the existing design aesthetic.