### PR TITLE
Add purple background to portfolio (MCP-133)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,7 @@
+body {
+    background-color: #7C3AED;
+}
+
 html{
     font-family: IBM Plex Mono;
 }


### PR DESCRIPTION
## Summary
This PR implements the requested purple background for the portfolio as specified in Jira ticket MCP-133.

## Changes Made
- **css/styles.css**: Added purple background color (`#7C3AED`) to the body element
- The color choice provides excellent contrast with the existing light text styling
- Maintains the existing IBM Plex Mono font family styling

## Visual Impact
- The entire portfolio now has a modern purple background
- Works well with the existing UIKit dark theme elements
- Maintains readability and accessibility standards

## Technical Details
- Color: `#7C3AED` (Medium purple)
- Applied to: `body` element for full page coverage
- Compatible with: Existing light text classes (`uk-light`)

## Testing
- Verified color contrast meets accessibility standards
- Compatible with existing UIKit framework styling
- Responsive design maintained across all screen sizes

**Resolves:** MCP-133