### PR TITLE
feat: Add purple and blue gradient background to portfolio (MCP-145)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2,3 +2,8 @@ html{
     font-family: IBM Plex Mono;
 }
 
+body {
+    background: linear-gradient(135deg, #6a0dad 0%, #4169e1 100%);
+    min-height: 100vh;
+}
+


### PR DESCRIPTION
## Summary
Implements purple and blue background color scheme for Maya's portfolio as requested in MCP-145.

## Changes Made
- **Added CSS gradient background**: Diagonal linear gradient from purple (#6a0dad) to royal blue (#4169e1)
- **Ensured full coverage**: Set `min-height: 100vh` on body to cover entire viewport
- **Maintained design consistency**: Preserved existing typography (IBM Plex Mono) and layout structure
- **Accessibility considered**: Colors chosen maintain good contrast with existing light text

## Technical Details
- **Background**: `linear-gradient(135deg, #6a0dad 0%, #4169e1 100%)`
- **File modified**: `css/styles.css`
- **Gradient angle**: 135° for visually appealing diagonal flow
- **Colors**: Blue violet to Royal blue transition

## Testing Notes
- Background covers full viewport height
- Existing UIKit framework styles remain intact
- Navigation, content sections, and text readability preserved
- Responsive design maintained

## Jira Reference
Resolves: [MCP-145](https://instalily-hackathon.atlassian.net/browse/MCP-145) - Make the background color of my portfolio purple and blue