### PR TITLE
Add purple background color to portfolio (MCP-149)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2,3 +2,7 @@ html{
     font-family: IBM Plex Mono;
 }
 
+body {
+    background-color: #663399;
+}
+


### PR DESCRIPTION
## Summary
This PR implements the requirement to make the background color purple for the simple portfolio template.

## Changes Made
- Added `background-color: #663399` to the body element in `css/styles.css`
- Used a dark purple color that maintains good contrast with the existing light text elements
- Preserves the dark theme aesthetic while meeting the purple background requirement

## Technical Details
- Color chosen: `#663399` (dark purple) for optimal readability
- Applied to body element to affect the entire page background
- Compatible with existing UK-kit framework classes like `uk-light`

## Testing
The change is minimal and straightforward - setting a CSS background color property. The purple background will be visible across all sections of the portfolio.

Resolves: MCP-149