### PR TITLE
Add Instalily ASCII art to portfolio homepage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2,3 +2,10 @@ html{
     font-family: IBM Plex Mono;
 }
 
+
+.ascii-art pre {
+    font-family: 'Courier New', monospace;
+    font-size: 1.2rem;
+    line-height: 1.2;
+    letter-spacing: 0.1em;
+}

--- a/index.html
+++ b/index.html
@@ -65,6 +65,20 @@
 </div>
 
 <!-- Navigation Bar Mobile Ends -->
+<!-- ASCII Art Section -->
+<section class="uk-margin-small-left uk-margin-small-right uk-margin-xlarge-top uk-margin-xlarge-bottom">
+    <div class="ascii-art uk-margin-xlarge-left uk-margin-xlarge-right">
+        <pre class="uk-light uk-text-center">
+ ___           _        _ _ _       
+|_ _|_ __  ___| |_ __ _| (_) |_   _ 
+ | || '_ \/ __| __/ _` | | | | | | |
+ | || | | \__ \ || (_| | | | | |_| |
+|___|_| |_|___/\__\__,_|_|_|_|\__, |
+                             |___/ 
+        </pre>
+    </div>
+</section>
+<!-- ASCII Art Section Ends -->
 <!-- Home -->
 <section class="uk-margin-small-left uk-margin-small-right uk-margin-xlarge-top uk-margin-xlarge-bottom">
     <h1 class="uk-margin-xlarge-left uk-light uk-text-left uk-margin-xlarge-right">I'm John Doe, a front-end web developer, <br>graphic designer, and an UI/UX designer.</h1>


### PR DESCRIPTION
This PR implements the requirements from Jira issue JPA-47 to add ASCII art saying "Instalily" to the portfolio.

## Changes Made:
- **HTML (index.html)**: Added a new ASCII art section that displays "Instalily" in stylized text format
- **CSS (css/styles.css)**: Added specific styling to ensure the ASCII art renders correctly with proper monospace fonts

## Implementation Details:
- The ASCII art is positioned prominently at the top of the page, right after the navigation but before the main content
- Used `<pre>` tag to preserve the ASCII art formatting
- Applied UIKit classes for consistent spacing and light text color
- Added custom CSS class `.ascii-art pre` for optimal monospace font rendering

## Visual Impact:
The ASCII art serves as an eye-catching brand element that immediately identifies the portfolio with "Instalily", enhancing the visual identity of the site.

Closes JPA-47