### PR TITLE
Make all text bold in portfolio

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,4 @@
 html{
     font-family: IBM Plex Mono;
+    font-weight: bold;
 }
-


### PR DESCRIPTION
## Summary
This PR implements the requested feature to make all text in the portfolio bold.

## Changes Made
- **css/styles.css**: Added `font-weight: bold` to the html selector

## Technical Details
- Applied bold styling at the html level to affect all text elements
- Maintains the existing IBM Plex Mono font family
- Simple and clean implementation that affects:
  - Navigation logo and menu items
  - Main heading and description text
  - About Me section content
  - Projects section titles and descriptions
  - All other text throughout the portfolio

## Testing
The change is straightforward CSS styling that will make all text appear bold while maintaining readability and the existing design structure.

## Impact
- ✅ All text in portfolio is now bold
- ✅ Maintains existing font family
- ✅ Clean, minimal CSS change
- ✅ No breaking changes to layout or functionality